### PR TITLE
Add kernel module building

### DIFF
--- a/cmd/compile/main.go
+++ b/cmd/compile/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -142,7 +143,7 @@ func run() error {
 	}
 
 	// copy modules
-	os.Rename(filepath.Join(kernelFolder, "modules_out"), dstFolder)
+	os.Rename(filepath.Join(kernelFolder, "modules_out/lib"), path.Join(dstFolder, "lib"))
 
 	// copy dtb files
 	files, err := filepath.Glob(filepath.Join(bootFolder, "dts", "bcm*-rpi-*.dtb"))

--- a/cmd/compile/main.go
+++ b/cmd/compile/main.go
@@ -36,6 +36,7 @@ const configAddendum = `
 # Basics
 CONFIG_SQUASHFS=y
 CONFIG_IPV6=y
+CONFIG_MODULES=y
 
 # Disable module compression (wifi needs this)
 CONFIG_MODULE_COMPRESS_NONE=y
@@ -70,8 +71,6 @@ func run() error {
 		"docker",
 		"run",
 		"--rm", // cleanup afterwards
-		"-e", "ARCH=arm",
-		"-e", "CROSS_COMPILE=arm-linux-gnueabihf-",
 		"-v", kernelFolder+":/root/armhf",
 		"ghcr.io/gokrazy-community/crossbuild-armhf:jammy-20220815",
 	)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/gokrazy-community/kernel-rpi-os-32
 
 go 1.18
 
-require github.com/magefile/mage v1.13.0
+require (
+	github.com/magefile/mage v1.13.0
+	github.com/otiai10/copy v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,9 @@
 github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
 github.com/magefile/mage v1.13.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=


### PR DESCRIPTION
Requires https://github.com/gokrazy-community/crossbuild-armhf/pull/2

This PR adds building some kernel modules, currently the same as the stock kernel (WiFi and Bluetooth).
It also changes the config alterations to be more in-line with the vanilla/stock kernel