### PR TITLE
Add instance config and GOARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 This repository holds a pre-built 32 bits Linux bits kernel image for the Raspberry Pi, compiled from https://github.com/raspberrypi/linux, for usage by the [gokrazy](https://github.com/gokrazy/gokrazy) project.
 
-To use the files in this repository, adjust the `-kernel_package`
-of `gokr-packer`:
+To use the files in this repository (as well as the corresponding firmware), set the `KernelPackage` and `FirmwarePackage` of your gokrazy instance's `config.json`:
+
+```jsonc
+{
+    // ...
+    "KernelPackage": "github.com/gokrazy-community/kernel-rpi-os-32/dist",
+    "FirmwarePackage": "github.com/gokrazy-community/firmware-rpi/dist"
+}
+```
+
+When building, make sure to set the appropriate `GOARCH` and `GOARM` environment variables:
 
 ```
-GOARCH=arm gokr-packer \
-    -kernel_package=github.com/gokrazy-community/kernel-rpi-os-32/dist \
-    github.com/gokrazy/hello
+GOARCH=arm GOARM=6 gok -i <instance-name> update
 ```
 
 ## How does it differ from https://github.com/gokrazy/kernel ?


### PR DESCRIPTION
As a beginner, I was struggling to understand how to use the kernel with instance-centric configuration of gokrazy. Additionally, a go-update suddenly broke gokrazy on my Raspberry, until the root-cause could be traced down to go defaulting to a wrong version of ARM (https://github.com/gokrazy/gokrazy/issues/239).

This PR changes the usage example at the top of the README to help new users find the right configuration and avoid common problems. Thank you for considering to merge it!

See also https://github.com/gokrazy-community/firmware-rpi/pull/2