### PR TITLE
Switch to current Debian stable release "Trixie"

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,15 +28,12 @@ jobs:
         if: steps.check.outputs.sha != ''
         id: fetch
         run: |
-          git submodule update --init
-          cd linux-sources
-          git fetch --depth=1 origin ${{steps.check.outputs.sha}}
-          git checkout ${{steps.check.outputs.sha}}
+          rm -rf linux-sources
+          git clone --depth=1 --revision ${{steps.check.outputs.sha}} https://github.com/raspberrypi/linux linux-sources
 
           # split lines to fail on exit != 0
-          version="$(make kernelversion)"
+          version="$(cd linux-sources && make kernelversion)"
           echo "version=$version" >> $GITHUB_OUTPUT
-          cd ..
           git diff --no-ext-diff
 
       - name: Compile latest kernel

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           commit_message: kernel ${{steps.fetch.outputs.version}}
           # bump the version below and add a force-update file to release a new version
-          tagging_message: v1.0.4-${{steps.fetch.outputs.version}}
+          tagging_message: v1.1.0-${{steps.fetch.outputs.version}}
 
       - name: Add blank commit regularly to keep cron alive (every 60 days)
         uses: gautamkrishnar/keepalive-workflow@v1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,6 +28,7 @@ jobs:
         if: steps.check.outputs.sha != ''
         id: fetch
         run: |
+          # update the submodule (faster than update/fetch/checkout)
           rm -rf linux-sources
           git clone --depth=1 --revision ${{steps.check.outputs.sha}} https://github.com/raspberrypi/linux linux-sources
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kernel for Raspberry Pi 32 bits (in sync with official bullseye repo)
+# Kernel for Raspberry Pi 32 bits (in sync with official trixie repo)
 
 This repository holds a pre-built 32 bits Linux bits kernel image for the Raspberry Pi, compiled from https://github.com/raspberrypi/linux, for usage by the [gokrazy](https://github.com/gokrazy/gokrazy) project.
 

--- a/cmd/check-update/main.go
+++ b/cmd/check-update/main.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/ulikunitz/xz"
@@ -26,11 +26,11 @@ func main() {
 }
 
 const baseURL = "https://archive.raspberrypi.org/debian/"
-const packagesGzURL = baseURL + "dists/bullseye/main/binary-armhf/Packages.gz"
+const packagesGzURL = baseURL + "dists/trixie/main/binary-armhf/Packages.gz"
 
 func run() error {
 	log.Println("checking:", packagesGzURL)
-	kernelPrefix := "Filename: pool/main/r/raspberrypi-firmware/raspberrypi-kernel_"
+	kernelPrefix := "Filename: pool/main/l/linux/linux-image-rpi-v6_"
 	version := ""
 	versionPrefix := "Version: "
 	found := false
@@ -55,8 +55,7 @@ func run() error {
 	if !found {
 		after = before
 	}
-	tagName, _, _ := strings.Cut(after, "-")
-	tagName, _, _ = strings.Cut(tagName, "~")
+	tagName, _, _ := strings.Cut(after, "~")
 
 	log.Println("latest version:", tagName)
 
@@ -85,46 +84,10 @@ func run() error {
 }
 
 func commitFromTag(tagName string) (string, error) {
-	latestSha, err := githubCommitSha(tagName)
-	log.Println("checking https://github.com/raspberrypi/linux tags")
-	if err == nil {
-		return latestSha, nil
-	}
-	log.Println(err)
-
-	xzURL := "https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/raspberrypi-firmware_" + tagName + ".orig.tar.xz"
+	xzURL := "https://archive.raspberrypi.org/debian/pool/main/l/linux/linux_" + tagName + ".debian.tar.xz"
 
 	log.Println("checking", xzURL)
 	return debianSourceCommitSha(xzURL)
-}
-
-func githubCommitSha(tagName string) (string, error) {
-	req, err := http.NewRequest("GET", "https://api.github.com/repos/raspberrypi/linux/git/ref/tags/"+tagName, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Add("Accept", "application/vnd.github.v3+json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	type githubResponse struct {
-		Message string `json:"message"`
-		Object  struct {
-			Sha string `json:"sha"`
-		} `json:"object"`
-	}
-	var gr githubResponse
-	err = json.NewDecoder(resp.Body).Decode(&gr)
-	if err != nil {
-		return "", err
-	}
-	if gr.Object.Sha == "" {
-		return "", fmt.Errorf("could not get sha for tag %q: %s", tagName, gr.Message)
-	}
-	return gr.Object.Sha, nil
 }
 
 func debianSourceCommitSha(xzURL string) (string, error) {
@@ -132,10 +95,14 @@ func debianSourceCommitSha(xzURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return "", fmt.Errorf("could not download package source: %s", resp.Status)
+	}
 	xzFile := resp.Body
 
 	//  for local testing
-	// xzFile, err := os.Open("raspberrypi-firmware_1.20230317.orig.tar.xz")
+	// xzFile, err := os.Open("linux_6.12.62-1+rpt1.debian.tar.xz")
 	// if err != nil {
 	// 	return "", err
 	// }
@@ -150,18 +117,28 @@ func debianSourceCommitSha(xzURL string) (string, error) {
 	for {
 		hdr, err := tr.Next()
 		if err != nil {
-			return "", fmt.Errorf("extra/git_hash not found: %w", err)
+			return "", fmt.Errorf("debian/changelog not found: %w", err)
 		}
-		if !strings.HasSuffix(hdr.Name, "/extra/git_hash") {
+		if !strings.HasSuffix(hdr.Name, "debian/changelog") {
 			continue
 		}
 
-		buf, err := io.ReadAll(tr)
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(string(buf)), nil
+		return debianChangelogCommitSha(tr)
 	}
+}
+
+func debianChangelogCommitSha(tr io.Reader) (string, error) {
+	re := regexp.MustCompile(`(?i)^\s*\*\s*Linux commit:\s*([0-9a-f]{7,40})\b`)
+	scanner := bufio.NewScanner(tr)
+	for scanner.Scan() {
+		if m := re.FindStringSubmatch(scanner.Text()); m != nil {
+			return m[1], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("debian/changelog does not contain 'Linux commit'");
 }
 
 func submoduleSha(submodule string) (string, error) {

--- a/cmd/check-update/main.go
+++ b/cmd/check-update/main.go
@@ -25,8 +25,10 @@ func main() {
 	}
 }
 
-const baseURL = "https://archive.raspberrypi.org/debian/"
-const packagesGzURL = baseURL + "dists/trixie/main/binary-armhf/Packages.gz"
+const (
+	baseURL       = "https://archive.raspberrypi.org/debian/"
+	packagesGzURL = baseURL + "dists/trixie/main/binary-armhf/Packages.gz"
+)
 
 func run() error {
 	log.Println("checking:", packagesGzURL)
@@ -137,7 +139,7 @@ func debianChangelogCommitSha(tr io.Reader) (string, error) {
 	if err := scanner.Err(); err != nil {
 		return "", err
 	}
-	return "", errors.New("debian/changelog does not contain 'Linux commit'");
+	return "", errors.New("debian/changelog does not contain 'Linux commit'")
 }
 
 func submoduleSha(submodule string) (string, error) {

--- a/cmd/check-update/main.go
+++ b/cmd/check-update/main.go
@@ -30,16 +30,15 @@ const packagesGzURL = baseURL + "dists/trixie/main/binary-armhf/Packages.gz"
 
 func run() error {
 	log.Println("checking:", packagesGzURL)
-	kernelPrefix := "Filename: pool/main/l/linux/linux-image-rpi-v6_"
+	packageName := "Package: linux-image-rpi-v6"
 	version := ""
 	versionPrefix := "Version: "
 	found := false
 	err := fetchAndScanGzTextFile(packagesGzURL, func(s string) bool {
-		if strings.HasPrefix(s, versionPrefix) {
-			version = s[len(versionPrefix):]
-		}
-		if strings.HasPrefix(s, kernelPrefix) {
+		if s == packageName {
 			found = true
+		} else if found && strings.HasPrefix(s, versionPrefix) {
+			version = s[len(versionPrefix):]
 			return true
 		}
 		return false

--- a/cmd/compile/main.go
+++ b/cmd/compile/main.go
@@ -75,7 +75,7 @@ func run() error {
 		"--enable", "MODULES",
 
 		// Disable module compression (wifi needs this)
-		"--enable", "MODULE_COMPRESS_NONE",
+		"--disable", "MODULE_COMPRESS",
 		"--disable", "MODULE_COMPRESS_GZIP",
 		"--disable", "MODULE_COMPRESS_XZ",
 		"--disable", "MODULE_COMPRESS_ZSTD",
@@ -185,15 +185,15 @@ func run() error {
 		return err
 	}
 	// remove unused symlinks
-	if err := os.Remove(filepath.Join(dstFolder, "lib", "modules", release, "build")); err != nil {
+	if err := os.Remove(filepath.Join(dstFolder, "lib", "modules", release, "build")); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.Remove(filepath.Join(dstFolder, "lib", "modules", release, "source")); err != nil {
+	if err := os.Remove(filepath.Join(dstFolder, "lib", "modules", release, "source")); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
 	// copy dtb files
-	files, err := filepath.Glob(filepath.Join(bootFolder, "dts", "bcm*-rpi-*.dtb"))
+	files, err := filepath.Glob(filepath.Join(bootFolder, "dts", "**/bcm*-rpi-*.dtb"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The currently used release Bullseye is EOL since 2024-08-14. The last kernel update was 3 years ago. To receive further updates we need to move on to a newer major release.

Kernel packing has changed, so migration is not straightforward. The only way I found to receive the current commit hash is parsing the changelog file. This is more a wonky convention than a well defined process.

Could be easier pulling new files directly from https://github.com/raspberrypi/firmware in feature. We might also ask there how to match upstream commits to released packages.